### PR TITLE
Prevent removing arbitrary files from the filesystem

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,6 +166,8 @@ summary {
 			return
 		} else if strings.HasPrefix(r.URL.Path, "/"+flagFolder+"/") {
 			filename := filepath.Clean(strings.TrimPrefix(r.URL.Path, "/"+flagFolder+"/"))
+			// This extra join implicitly does a clean and thereby prevents directory traversal
+			filename = path.Join("/", filename)
 			filename = path.Join(flagFolder, filename)
 			v, ok := r.URL.Query()["remove"]
 			if ok && v[0] == "true" {


### PR DESCRIPTION
Before this change you could do:

  touch killme.txt # in base of project, outside of archive
  curl -v 'http://localhost:9222/archived/%2E%2E/killme.txt?remove=true'

... and the `killme.txt` file is GONE! Like magic.